### PR TITLE
Add Google Ads tag and conversion tracking

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -68,7 +68,12 @@ import LocationMap from '../assets/location.png';
                 >
                   <Icon name="mdi:whatsapp" class="h-6 w-6" />
                 </a>
-                <span class="text-xl">{contact.phone}</span>
+                <a
+                  href={`tel:${contact.phone}`}
+                  class="text-xl transition-colors hover:text-blue-700"
+                >
+                  {contact.phone}
+                </a>
               </div>
               <a
                 href={contact.facebook}
@@ -170,7 +175,12 @@ import LocationMap from '../assets/location.png';
               >
                 <Icon name="mdi:whatsapp" class="h-5 w-5" />
               </a>
-              <span class="text-xl">{contact.phone}</span>
+              <a
+                href={`tel:${contact.phone}`}
+                class="text-xl transition-colors hover:text-blue-700"
+              >
+                {contact.phone}
+              </a>
             </div>
             <a
               href={contact.facebook}

--- a/src/config/analytics.ts
+++ b/src/config/analytics.ts
@@ -1,0 +1,25 @@
+// Google Ads (gtag.js) conversion tracking.
+//
+// Each value below is the `send_to` string for a Google Ads conversion action,
+// in the form: AW-<account id>/<conversion label>
+//
+// Where to find the label: Google Ads -> Goals -> Conversions -> open the
+// conversion action -> "Tag setup" -> "Install the tag yourself". The snippet
+// shows an event with  send_to: 'AW-11007801742/AbC-dEfGh1i2j3'  -- copy the
+// part after the slash into the matching constant below.
+//
+// NOTE: the AW-11007801742 account id must match the gtag snippet in
+// src/layouts/Layout.astro.
+
+export const GOOGLE_ADS_ID = 'AW-11007801742';
+
+export const conversions = {
+  // Click on any WhatsApp link (sticky button, footer, PrimaryButton CTAs).
+  whatsapp: `${GOOGLE_ADS_ID}/REPLACE_WITH_WHATSAPP_LABEL`,
+  // Click on any tel: link (footer phone, thank-you page).
+  call: `${GOOGLE_ADS_ID}/REPLACE_WITH_CALL_LABEL`,
+  // Successful contact form submission.
+  form: `${GOOGLE_ADS_ID}/REPLACE_WITH_FORM_LABEL`,
+};
+
+export default { GOOGLE_ADS_ID, conversions };

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -7,6 +7,7 @@ import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
 import StickyWhatsApp from '../assets/sticky-whatsapp.svg';
 import contact from '../config/contact';
+import { conversions } from '../config/analytics';
 
 interface Props {
   title: string;
@@ -25,6 +26,18 @@ const canonicalUrl = new URL(Astro.url.pathname, siteUrl).href;
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+    <!-- Google tag (gtag.js) -->
+    <script is:inline async src="https://www.googletagmanager.com/gtag/js?id=AW-11007801742"></script>
+    <script is:inline>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag('js', new Date());
+      gtag('config', 'AW-11007801742');
+    </script>
+
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="generator" content={Astro.generator} />
     <title>{title}</title>
@@ -108,5 +121,59 @@ const canonicalUrl = new URL(Astro.url.pathname, siteUrl).href;
         <StickyWhatsApp class="h-12 w-12 md:h-16 md:w-16" />
       </a>
     </div>
+
+    <!-- Google Ads conversion tracking for WhatsApp + call (tel:) link clicks -->
+    <script define:vars={{ conversions }}>
+      (function () {
+        // The delegated listener lives on `document`, which survives Astro's
+        // ClientRouter navigations. Guard so it is attached exactly once even if
+        // this inline script re-runs on a page transition.
+        if (window.__adsClickTrackingInit) return;
+        window.__adsClickTrackingInit = true;
+
+        function trackClick(sendTo, link, event) {
+          if (typeof window.gtag !== 'function' || !sendTo) return;
+
+          // Links opening a new tab/window keep this page alive, so the beacon
+          // sends on its own — just fire the event and let navigation proceed.
+          var opensNewContext =
+            link.target === '_blank' ||
+            event.metaKey ||
+            event.ctrlKey ||
+            event.shiftKey ||
+            event.button === 1;
+
+          if (opensNewContext) {
+            window.gtag('event', 'conversion', { send_to: sendTo });
+            return;
+          }
+
+          // Same-tab navigation: hold it until the event is sent, with a
+          // timeout fallback so a blocked/slow gtag never traps the user.
+          var url = link.href;
+          var navigated = false;
+          var go = function () {
+            if (navigated) return;
+            navigated = true;
+            window.location.href = url;
+          };
+          event.preventDefault();
+          window.gtag('event', 'conversion', { send_to: sendTo, event_callback: go });
+          setTimeout(go, 900);
+        }
+
+        document.addEventListener('click', function (event) {
+          var target = event.target;
+          var link = target && target.closest ? target.closest('a[href]') : null;
+          if (!link) return;
+          var href = link.getAttribute('href') || '';
+          if (href.indexOf('https://wa.me/') === 0) {
+            trackClick(conversions.whatsapp, link, event);
+          } else if (href.indexOf('tel:') === 0) {
+            trackClick(conversions.call, link, event);
+          }
+        });
+      })();
+    </script>
   </body>
 </html>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -125,6 +125,8 @@ import spitalImage from '../assets/spital/spital_morning.jpg';
 </Layout>
 
 <script>
+  import { conversions } from '../config/analytics';
+
   document.addEventListener('astro:page-load', () => {
     const form = document.getElementById('contact-form-element') as HTMLFormElement | null;
     if (!form) return;
@@ -160,7 +162,25 @@ import spitalImage from '../assets/spital/spital_morning.jpg';
         });
 
         if (response.ok) {
-          window.location.href = '/thank-you?status=success';
+          // Fire the Google Ads conversion, then redirect. event_callback keeps
+          // the redirect from racing the beacon; setTimeout is the fallback if
+          // gtag is blocked or slow.
+          const redirect = () => {
+            window.location.href = '/thank-you?status=success';
+          };
+          const gtag = (window as any).gtag;
+          if (typeof gtag === 'function' && conversions.form) {
+            let done = false;
+            const go = () => {
+              if (done) return;
+              done = true;
+              redirect();
+            };
+            gtag('event', 'conversion', { send_to: conversions.form, event_callback: go });
+            setTimeout(go, 900);
+          } else {
+            redirect();
+          }
         } else {
           window.location.href = '/thank-you?status=error';
         }


### PR DESCRIPTION
Adds the Google Ads global site tag and conversion tracking.

## Changes
- **Base tag**: gtag.js (`AW-11007801742`) added to the shared `Layout.astro` head — loads on every page.
- **Conversion tracking** for three actions:
  - **WhatsApp** — delegated click handler on any `wa.me` link (sticky button, footer, `PrimaryButton` CTAs)
  - **Call** — click handler on any `tel:` link
  - **Contact form** — fires only on a successful send, before redirect
- **`src/config/analytics.ts`** — single source of truth for the conversion `send_to` values.
- **Footer** — phone number is now a clickable `tel:` link (desktop + mobile).

## Note
Conversion labels are placeholders (`REPLACE_WITH_*_LABEL`) pending Google Ads conversion-action setup. Deploying now so Google Ads can **detect the base tag**; a follow-up will drop in the real labels.

Verified in a local browser: all three conversions push to `dataLayer` with the correct `send_to`; build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)