### PR TITLE
Track calls via Google Ads dynamic number insertion

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -70,7 +70,7 @@ import LocationMap from '../assets/location.png';
                 </a>
                 <a
                   href={`tel:${contact.phone}`}
-                  class="text-xl transition-colors hover:text-blue-700"
+                  class="js-call-number text-xl transition-colors hover:text-blue-700"
                 >
                   {contact.phone}
                 </a>
@@ -177,7 +177,7 @@ import LocationMap from '../assets/location.png';
               </a>
               <a
                 href={`tel:${contact.phone}`}
-                class="text-xl transition-colors hover:text-blue-700"
+                class="js-call-number text-xl transition-colors hover:text-blue-700"
               >
                 {contact.phone}
               </a>

--- a/src/config/analytics.ts
+++ b/src/config/analytics.ts
@@ -1,23 +1,21 @@
 // Google Ads (gtag.js) conversion tracking.
 //
-// Each value below is the `send_to` string for a Google Ads conversion action,
-// in the form: AW-<account id>/<conversion label>
+// These are the `send_to` values for EVENT-based conversion actions, fired via
+//   gtag('event', 'conversion', { send_to: ... })
+// Format: AW-<account id>/<conversion label>. Find the label in Google Ads ->
+// Goals -> Conversions -> [action] -> "Tag setup" -> the part after the slash.
 //
-// Where to find the label: Google Ads -> Goals -> Conversions -> open the
-// conversion action -> "Tag setup" -> "Install the tag yourself". The snippet
-// shows an event with  send_to: 'AW-11007801742/AbC-dEfGh1i2j3'  -- copy the
-// part after the slash into the matching constant below.
+// Call tracking is NOT here: it uses Google's dynamic number insertion
+// ("Calls from a website" conversion action), configured directly in the gtag
+// snippet in src/layouts/Layout.astro.
 //
-// NOTE: the AW-11007801742 account id must match the gtag snippet in
-// src/layouts/Layout.astro.
+// NOTE: the AW-11007801742 account id must match the gtag snippet in Layout.astro.
 
 export const GOOGLE_ADS_ID = 'AW-11007801742';
 
 export const conversions = {
   // Click on any WhatsApp link (sticky button, footer, PrimaryButton CTAs).
   whatsapp: `${GOOGLE_ADS_ID}/REPLACE_WITH_WHATSAPP_LABEL`,
-  // Click on any tel: link (footer phone, thank-you page).
-  call: `${GOOGLE_ADS_ID}/REPLACE_WITH_CALL_LABEL`,
   // Successful contact form submission.
   form: `${GOOGLE_ADS_ID}/REPLACE_WITH_FORM_LABEL`,
 };

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -36,6 +36,32 @@ const canonicalUrl = new URL(Astro.url.pathname, siteUrl).href;
       }
       gtag('js', new Date());
       gtag('config', 'AW-11007801742');
+
+      // Call conversion tracking via dynamic number insertion ("Calls from a
+      // website"). For visitors arriving from a Google Ad, Google supplies a
+      // forwarding number; the callback rewrites the displayed number and tel:
+      // links (marked with .js-call-number) so calls route through it and are
+      // counted. Non-ad visitors keep the normal number untouched.
+      (function () {
+        var forwarding = null;
+        function applyForwardingNumber() {
+          if (!forwarding) return;
+          var els = document.getElementsByClassName('js-call-number');
+          for (var i = 0; i < els.length; i++) {
+            els[i].setAttribute('href', 'tel:' + forwarding.mobile);
+            els[i].textContent = forwarding.formatted;
+          }
+        }
+        gtag('config', 'AW-11007801742/dgy-CP6W_fkDEI7z9oAp', {
+          phone_conversion_number: '0722 777 542',
+          phone_conversion_callback: function (formatted_number, mobile_number) {
+            forwarding = { formatted: formatted_number, mobile: mobile_number };
+            applyForwardingNumber();
+          },
+        });
+        // Re-apply after client-side (ClientRouter) navigations swap the DOM.
+        document.addEventListener('astro:page-load', applyForwardingNumber);
+      })();
     </script>
 
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
@@ -122,7 +148,7 @@ const canonicalUrl = new URL(Astro.url.pathname, siteUrl).href;
       </a>
     </div>
 
-    <!-- Google Ads conversion tracking for WhatsApp + call (tel:) link clicks -->
+    <!-- Google Ads conversion tracking for WhatsApp link clicks -->
     <script define:vars={{ conversions }}>
       (function () {
         // The delegated listener lives on `document`, which survives Astro's
@@ -169,8 +195,6 @@ const canonicalUrl = new URL(Astro.url.pathname, siteUrl).href;
           var href = link.getAttribute('href') || '';
           if (href.indexOf('https://wa.me/') === 0) {
             trackClick(conversions.whatsapp, link, event);
-          } else if (href.indexOf('tel:') === 0) {
-            trackClick(conversions.call, link, event);
           }
         });
       })();

--- a/src/pages/thank-you.astro
+++ b/src/pages/thank-you.astro
@@ -39,7 +39,7 @@ import contact from '../config/contact';
           sau telefonic la
           <a
             href={`tel:${contact.phone}`}
-            class="font-semibold text-black underline hover:text-gray-700"
+            class="js-call-number font-semibold text-black underline hover:text-gray-700"
           >
             {contact.phone}
           </a>


### PR DESCRIPTION
Switches call tracking to Google's **"Calls from a website"** dynamic number insertion (DNI), reusing the existing conversion action `AW-11007801742/dgy-CP6W_fkDEI7z9oAp`.

## Changes
- **DNI config + callback** added to the gtag snippet in `Layout.astro`. For visitors arriving from a Google Ad, Google supplies a forwarding number and the callback rewrites the displayed number and `tel:` hrefs so calls route through it and are counted. Non-ad visitors keep the normal number.
- **`.js-call-number`** marks the phone links (footer desktop + mobile, thank-you page) that the callback targets.
- Forwarding number is **re-applied after `ClientRouter` navigations**.
- Removed the click-based `tel:` branch and the `call` entry from `analytics.ts` so calls aren't double-counted.

## Verified locally
- 0 console errors; DNI config pushed to `dataLayer`; `.js-call-number` targets present.
- WhatsApp click tracking still fires; `tel:` clicks no longer fire a duplicate event.
- Full call-forwarding allocation can only be confirmed in production via a real ad click (needs a `gclid`).

## Still pending
WhatsApp and Form conversion labels are placeholders (`REPLACE_WITH_*_LABEL`) awaiting the real labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)